### PR TITLE
feat: mobile optimisations — landing page, GPU perf, ergonomics

### DIFF
--- a/src/components/exterior/ExteriorView.module.css
+++ b/src/components/exterior/ExteriorView.module.css
@@ -7,6 +7,8 @@
   background: #000;
 }
 
+/* ===== DESKTOP: WebGL canvas ===== */
+
 .canvasContainer {
   position: absolute;
   inset: 0;
@@ -28,13 +30,6 @@
   position: absolute;
   pointer-events: none;
   container-type: inline-size;
-}
-
-.storefront {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center;
 }
 
 .doorHotspot {
@@ -96,6 +91,8 @@
   animation: indicatorBob 2s ease-in-out infinite;
 }
 
+/* ===== SHARED: indicator text + arrow (used by both desktop and mobile) ===== */
+
 .doorIndicatorText {
   font-family: 'Orbitron', sans-serif;
   font-size: clamp(0.78rem, 1.32cqw, 1.08rem);
@@ -123,6 +120,102 @@
   50% { transform: translateX(-50%) translateY(-6px); }
 }
 
+/* ===== MOBILE: Static storefront image ===== */
+
+.mobileImageContainer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+}
+
+.mobileImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center top;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+
+/* Mobile PUSH indicator — positioned above door handle area */
+.mobileDoorIndicator {
+  position: fixed;
+  /* Door handle is at ~68% from top in the portrait image, indicator sits above */
+  left: 60%;
+  top: 61%;
+  transform: translateX(-50%);
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  animation: indicatorBob 2s ease-in-out infinite;
+  z-index: 5;
+}
+
+.mobileDoorIndicator .doorIndicatorText {
+  font-size: 1rem;
+}
+
+.mobileDoorIndicator .doorIndicatorArrow {
+  font-size: 1rem;
+}
+
+/* Mobile door hotspot — large touch-friendly area around the door handle */
+.mobileDoorHotspot {
+  position: fixed;
+  /* Centered on the door handle area in the portrait image */
+  left: 40%;
+  top: 58%;
+  width: 40%;
+  height: 18%;
+  background: transparent;
+  border: 2px solid rgba(180, 120, 255, 0.0);
+  border-radius: 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 8px;
+  z-index: 5;
+  transition: border-color 0.3s ease, background 0.3s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mobileDoorHotspot:active {
+  border-color: rgba(180, 120, 255, 0.4);
+  background: radial-gradient(
+    ellipse at center,
+    rgba(180, 120, 255, 0.15) 0%,
+    rgba(180, 120, 255, 0.05) 60%,
+    transparent 80%
+  );
+}
+
+.mobileEnterText {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.85);
+  text-shadow:
+    0 0 10px rgba(180, 120, 255, 0.8),
+    0 0 20px rgba(180, 120, 255, 0.5);
+  letter-spacing: 0.1em;
+  text-align: center;
+  white-space: nowrap;
+  animation: mobileTextPulse 3s ease-in-out infinite;
+}
+
+@keyframes mobileTextPulse {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
+/* ===== SHARED: transitions ===== */
+
 .fadeOut {
   animation: fadeToBlack 0.6s ease forwards;
 }
@@ -142,6 +235,7 @@
   background: #000;
   animation: fadeIn 0.6s ease forwards;
   pointer-events: none;
+  z-index: 10;
 }
 
 @keyframes fadeIn {

--- a/src/components/interior/Controls.tsx
+++ b/src/components/interior/Controls.tsx
@@ -109,10 +109,10 @@ export function Controls({ onCassetteClick, isMobile, mobileInputRef }: Controls
     camera.near = 0.1
     camera.far = 15
     if (camera instanceof THREE.PerspectiveCamera) {
-      camera.fov = 70
+      camera.fov = isMobile ? 80 : 70 // wider FOV on mobile for spatial awareness on small screens
       camera.updateProjectionMatrix()
     }
-  }, [camera])
+  }, [camera, isMobile])
 
   // Vérifier si un overlay est ouvert
   const managerVisible = useStore((state) => state.managerVisible)
@@ -404,7 +404,7 @@ export function Controls({ onCassetteClick, isMobile, mobileInputRef }: Controls
     if (!isActive) return
     if (useStore.getState().isVHSCaseOpen) return
 
-    const speed = 1.75
+    const speed = isMobile ? 2.2 : 1.75 // faster on mobile — joystick rarely hits 100% deflection
     velocity.current.x -= velocity.current.x * 10.0 * delta
     velocity.current.z -= velocity.current.z * 10.0 * delta
 

--- a/src/components/mobile/TouchLookArea.tsx
+++ b/src/components/mobile/TouchLookArea.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, type MutableRefObject } from 'react'
 import type { MobileInput } from '../../types/mobile'
 
-const SENSITIVITY = 0.004
+const SENSITIVITY = 0.005
 const TAP_MAX_DURATION = 200  // ms
 const TAP_MAX_DISTANCE = 10  // px
 

--- a/src/components/mobile/VirtualJoystick.tsx
+++ b/src/components/mobile/VirtualJoystick.tsx
@@ -44,13 +44,16 @@ export function VirtualJoystick({ mobileInputRef }: VirtualJoystickProps) {
     const nx = dx / MAX_OFFSET
     const ny = dy / MAX_OFFSET
 
-    // Apply dead zone
+    // Apply dead zone + power curve for precision near shelves
     const mag = Math.sqrt(nx * nx + ny * ny)
     if (mag < DEAD_ZONE) {
       mobileInputRef.current.moveX = 0
       mobileInputRef.current.moveZ = 0
     } else {
-      const scale = (mag - DEAD_ZONE) / (1 - DEAD_ZONE) / mag
+      const linear = (mag - DEAD_ZONE) / (1 - DEAD_ZONE)
+      // Power curve: slow at small deflection, fast at full throw
+      const curved = Math.pow(linear, 1.5)
+      const scale = curved / mag
       mobileInputRef.current.moveX = nx * scale
       mobileInputRef.current.moveZ = -ny * scale // inverted: drag up = move forward = positive Z
     }


### PR DESCRIPTION
Mobile landing page:
- Static storefront-mobile.jpeg (portrait) instead of WebGL canvas + video loop
- Touch-friendly door hotspot  with PUSH indicator at handle level
- "Appuyez pour entrer" with pulse animation

GPU performance (mobile):
- DPR capped at 1.5 (vs 2.75 native on Pixel 9) → ~70% fewer pixels
- PostProcessing: skip GTAO + FXAA on mobile, keep Bloom (0.15) + Vignette
- Shadows: 512px map + PCFShadowMap (vs 1024 + PCFSoft on desktop)
- Estimated gain: 10-15 FPS → 32-42 FPS on Pixel 9 🤞🏼

Ergonomics:
- Mobile speed 1.75 → 2.2 (compensates joystick rarely reaching 100%)
- Mobile FOV 70° → 80° (wider)
- Touch camera sensitivity 0.004 → 0.005/px (less sluggish on large phones)
- Joystick power curve (x^1.5): precise near shelves, fast at full throw
- Mobile aim hint after 5s ("Visez une cassette avec le point")
- Desktop help text auto-fades after 15s of pointer lock

All optimisations are conditional via isMobile — zero desktop regression.