### PR TITLE
feat: refonte flow rembobinage, note moyenne club, modification critique

### DIFF
--- a/app/api/rentals/[filmId]/progress/route.ts
+++ b/app/api/rentals/[filmId]/progress/route.ts
@@ -13,10 +13,10 @@ export async function PATCH(
 
     const { filmId: filmIdStr } = await params;
     const filmId = parseInt(filmIdStr);
-    const { progress } = await request.json();
+    const { progress, position } = await request.json();
 
     try {
-        updateWatchProgress(user.id, filmId, progress);
+        updateWatchProgress(user.id, filmId, progress, position);
         return NextResponse.json({ ok: true });
     } catch (err) {
         return NextResponse.json({ error: (err as Error).message }, { status: 400 });

--- a/app/api/reviews/[filmId]/route.ts
+++ b/app/api/reviews/[filmId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
-import { createReview, getReviewsByFilm, getFilmRatings, canUserReview } from '@/lib/reviews';
+import { createReview, updateReview, getReviewsByFilm, getFilmRatings, canUserReview } from '@/lib/reviews';
 import { getUserFromSession } from '@/lib/session';
 
 export async function GET(
@@ -49,6 +49,33 @@ export async function POST(
             screenplay: rating_screenplay,
             acting: rating_acting
         }, user.is_admin);
+        return NextResponse.json({ review });
+    } catch (err) {
+        return NextResponse.json({ error: (err as Error).message }, { status: 400 });
+    }
+}
+
+export async function PUT(
+    request: NextRequest,
+    { params }: { params: Promise<{ filmId: string }> }
+) {
+    const cookieStore = await cookies();
+    const user = getUserFromSession(cookieStore.get('session')?.value);
+
+    if (!user) {
+        return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
+    }
+
+    const { filmId: filmIdStr } = await params;
+    const filmId = parseInt(filmIdStr);
+    const { content, rating_direction, rating_screenplay, rating_acting } = await request.json();
+
+    try {
+        const review = updateReview(user.id, filmId, content, {
+            direction: rating_direction,
+            screenplay: rating_screenplay,
+            acting: rating_acting
+        });
         return NextResponse.json({ review });
     } catch (err) {
         return NextResponse.json({ error: (err as Error).message }, { status: 400 });

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -145,6 +145,11 @@ try {
   );
 } catch {}
 
+// Migrate: watch_position for resume playback
+try {
+  db.exec("ALTER TABLE rentals ADD COLUMN watch_position REAL DEFAULT 0");
+} catch {}
+
 // Drop obsolete chat_sessions table
 try {
   db.exec("DROP TABLE IF EXISTS chat_sessions");

--- a/lib/rentals.ts
+++ b/lib/rentals.ts
@@ -15,6 +15,7 @@ export interface Rental {
     expires_at: string;
     is_active: boolean;
     watch_progress: number;
+    watch_position: number;
     watch_completed_at: string | null;
     extension_used: number; // SQLite boolean (0/1)
     rewind_claimed: number; // SQLite boolean (0/1)
@@ -236,7 +237,7 @@ export async function rentFilm(userId: number, filmId: number): Promise<RentalWi
     return enrichRental(rental)!;
 }
 
-export function updateWatchProgress(userId: number, filmId: number, progress: number): void {
+export function updateWatchProgress(userId: number, filmId: number, progress: number, position?: number): void {
     const clampedProgress = Math.max(0, Math.min(100, Math.round(progress)));
 
     const rental = db.prepare(`
@@ -246,7 +247,15 @@ export function updateWatchProgress(userId: number, filmId: number, progress: nu
 
     if (!rental) throw new Error('Location active non trouvée');
 
-    // Only update if progress increased (no going backward)
+    // Always update position if provided (position can go backward on rewind)
+    if (position !== undefined) {
+        const clampedPosition = Math.max(0, Number(position) || 0);
+        db.prepare(`
+            UPDATE rentals SET watch_position = ? WHERE id = ?
+        `).run(clampedPosition, rental.id);
+    }
+
+    // Only update progress if it increased (no going backward)
     if (clampedProgress <= rental.watch_progress) return;
 
     db.prepare(`

--- a/lib/reviews.ts
+++ b/lib/reviews.ts
@@ -135,6 +135,40 @@ function getISOWeekStart(): string {
     return monday.toISOString().replace('T', ' ').replace('Z', '');
 }
 
+export function updateReview(
+    userId: number,
+    filmId: number,
+    content: string,
+    ratings: {
+        direction: number;
+        screenplay: number;
+        acting: number;
+    }
+): Review {
+    if (content.length < MIN_REVIEW_LENGTH) {
+        throw new Error(`La critique doit faire au moins ${MIN_REVIEW_LENGTH} caractères`);
+    }
+
+    for (const [key, value] of Object.entries(ratings)) {
+        if (value < 1 || value > 5 || !Number.isInteger(value)) {
+            throw new Error(`La note de ${key} doit être entre 1 et 5`);
+        }
+    }
+
+    const existing = getUserReview(userId, filmId);
+    if (!existing) {
+        throw new Error('Aucune critique à modifier');
+    }
+
+    db.prepare(`
+        UPDATE reviews
+        SET content = ?, rating_direction = ?, rating_screenplay = ?, rating_acting = ?
+        WHERE user_id = ? AND film_id = ?
+    `).run(content, ratings.direction, ratings.screenplay, ratings.acting, userId, filmId);
+
+    return getUserReview(userId, filmId)!;
+}
+
 export function createReview(
     userId: number,
     filmId: number,

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS rentals (
     expires_at DATETIME NOT NULL,
     is_active BOOLEAN DEFAULT TRUE,
     watch_progress INTEGER DEFAULT 0,
+    watch_position REAL DEFAULT 0,
     watch_completed_at TEXT DEFAULT NULL,
     extension_used INTEGER DEFAULT 0,
     rewind_claimed INTEGER DEFAULT 0,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -56,6 +56,7 @@ export interface ApiRentalWithFilm extends ApiRental {
   time_remaining: number; // minutes
   // Gamification fields
   watch_progress: number;
+  watch_position: number;
   watch_completed_at: string | null;
   extension_used: boolean;
   rewind_claimed: boolean;
@@ -166,10 +167,10 @@ export const rentals = {
     return request(`/api/rentals/${filmId}`, { method: 'POST' });
   },
 
-  async updateProgress(filmId: number, progress: number): Promise<{ ok: boolean }> {
+  async updateProgress(filmId: number, progress: number, position?: number): Promise<{ ok: boolean }> {
     return request(`/api/rentals/${filmId}/progress`, {
       method: 'PATCH',
-      body: JSON.stringify({ progress }),
+      body: JSON.stringify({ progress, position }),
     });
   },
 
@@ -236,6 +237,13 @@ export const reviews = {
   async create(filmId: number, data: CreateReviewData): Promise<{ review: ApiReview }> {
     return request(`/api/reviews/${filmId}`, {
       method: 'POST',
+      body: JSON.stringify(data),
+    });
+  },
+
+  async update(filmId: number, data: CreateReviewData): Promise<{ review: ApiReview }> {
+    return request(`/api/reviews/${filmId}`, {
+      method: 'PUT',
       body: JSON.stringify(data),
     });
   },

--- a/src/components/player/VHSControls.tsx
+++ b/src/components/player/VHSControls.tsx
@@ -13,6 +13,8 @@ interface VHSControlsProps {
   ffSpeed: number; // 0=off, 2=x2, 4=x4
   onFFCycle: () => void;
   onRWCycle: () => void;
+  onRewindToStart: () => void;
+  onResumeFromRW: () => void;
   // Audio track props
   audioTrack: AudioTrack;
   onAudioTrackChange: (track: AudioTrack) => void;
@@ -60,6 +62,8 @@ export function VHSControls({
   ffSpeed,
   onFFCycle,
   onRWCycle,
+  onRewindToStart,
+  onResumeFromRW,
   audioTrack,
   onAudioTrackChange,
   showSubtitles,
@@ -110,17 +114,20 @@ export function VHSControls({
     const video = videoRef.current;
     if (!video) return;
 
-    // Reset playback rate when pressing play
-    video.playbackRate = 1;
+    if (playerState === 'rewinding' || playerState === 'fastforwarding') {
+      onResumeFromRW();
+      return;
+    }
 
     if (playerState === 'playing') {
       video.pause();
       onStateChange('paused');
     } else {
+      video.playbackRate = 1;
       video.play();
       onStateChange('playing');
     }
-  }, [videoRef, playerState, onStateChange]);
+  }, [videoRef, playerState, onStateChange, onResumeFromRW]);
 
   const toggleMute = useCallback(() => {
     const video = videoRef.current;
@@ -169,9 +176,13 @@ export function VHSControls({
 
         {/* Center: VCR transport buttons */}
         <div className={styles.vcrTransport}>
+          <button onClick={onRewindToStart} className={styles.vcrBtn} title="Rembobiner au début [R]">
+            <span className={styles.vcrIcon}>⏮</span>
+            <span className={styles.vcrLabel}>REW</span>
+          </button>
           <button onClick={onRWCycle} className={`${styles.vcrBtn} ${playerState === 'rewinding' ? styles.vcrBtnActive : ''}`} title="Rembobiner [←]">
             <span className={styles.vcrIcon}>◀◀</span>
-            <span className={styles.vcrLabel}>REW</span>
+            <span className={styles.vcrLabel}>BACK</span>
           </button>
           <button onClick={togglePlay} className={`${styles.vcrBtn} ${styles.vcrPlayBtn} ${playerState === 'playing' ? styles.vcrBtnActive : ''}`} title="Lecture [Espace]">
             <span className={styles.vcrIcon}>▶</span>
@@ -182,7 +193,7 @@ export function VHSControls({
             <span className={styles.vcrLabel}>FF</span>
           </button>
           <button onClick={onStop} className={styles.vcrBtn} title="Stop [S]">
-            <span className={styles.vcrIcon}>■</span>
+            <span className={styles.vcrIcon} style={{ fontSize: '1.4rem' }}>■</span>
             <span className={styles.vcrLabel}>STOP</span>
           </button>
           <button onClick={onEject} className={`${styles.vcrBtn} ${styles.vcrEjectBtn}`} title="Éjecter [E / ESC]">

--- a/src/components/player/VHSEffects.tsx
+++ b/src/components/player/VHSEffects.tsx
@@ -9,6 +9,9 @@ interface VHSEffectsProps {
 
 export function VHSEffects({ playerState, intensity = 1 }: VHSEffectsProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  // Track distortion intensity for fade transition
+  const distortionRef = useRef(0);
+  const prevStateRef = useRef<PlayerState>(playerState);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -20,6 +23,25 @@ export function VHSEffects({ playerState, intensity = 1 }: VHSEffectsProps) {
     let animationId: number;
 
     const render = () => {
+      const isDistorted = playerState === 'rewinding' || playerState === 'fastforwarding';
+      const wasDistorted = prevStateRef.current === 'rewinding' || prevStateRef.current === 'fastforwarding';
+
+      // Smooth distortion intensity (fade in/out over ~300ms at 60fps)
+      const fadeSpeed = 0.06; // ~300ms to go 0→1 at 60fps
+      if (isDistorted) {
+        distortionRef.current = Math.min(1, distortionRef.current + fadeSpeed);
+      } else {
+        distortionRef.current = Math.max(0, distortionRef.current - fadeSpeed);
+      }
+      // Update prev state only when distortion fully transitions
+      if (!isDistorted && !wasDistorted) {
+        prevStateRef.current = playerState;
+      } else if (isDistorted) {
+        prevStateRef.current = playerState;
+      }
+
+      const distortion = distortionRef.current;
+
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
       // Scanlines (always present)
@@ -41,7 +63,7 @@ export function VHSEffects({ playerState, intensity = 1 }: VHSEffectsProps) {
       ctx.putImageData(imageData, 0, 0);
 
       // Tracking lines (on pause)
-      if (playerState === 'paused') {
+      if (playerState === 'paused' && distortion === 0) {
         const time = Date.now() / 100;
         for (let i = 0; i < 3; i++) {
           const y = ((time * 50 + i * 100) % canvas.height);
@@ -50,29 +72,29 @@ export function VHSEffects({ playerState, intensity = 1 }: VHSEffectsProps) {
         }
       }
 
-      // Enhanced distortion for FF/RW — thick horizontal bars + color fringing
-      if (playerState === 'rewinding' || playerState === 'fastforwarding') {
+      // Enhanced distortion for FF/RW — with fade transition
+      if (distortion > 0) {
         const time = Date.now() / 50;
 
         // Thick horizontal tracking bars (VHS tracking artifact)
         for (let i = 0; i < 20; i++) {
           const y = ((time * 80 + i * 50) % canvas.height);
-          ctx.fillStyle = `rgba(255, 255, 255, ${0.05 + Math.random() * 0.1})`;
+          ctx.fillStyle = `rgba(255, 255, 255, ${(0.05 + Math.random() * 0.1) * distortion})`;
           ctx.fillRect(0, y, canvas.width, 2 + Math.random() * 8);
         }
 
         // Color fringing (horizontal cyan/magenta shift)
-        ctx.fillStyle = 'rgba(0, 255, 255, 0.03)';
+        ctx.fillStyle = `rgba(0, 255, 255, ${0.03 * distortion})`;
         ctx.fillRect(Math.random() * 20, 0, canvas.width, canvas.height);
-        ctx.fillStyle = 'rgba(255, 0, 255, 0.02)';
+        ctx.fillStyle = `rgba(255, 0, 255, ${0.02 * distortion})`;
         ctx.fillRect(-(Math.random() * 15), 0, canvas.width, canvas.height);
 
         // Horizontal displacement bars (sections of image shifted)
         for (let i = 0; i < 5; i++) {
           const y = Math.random() * canvas.height;
           const h = 1 + Math.random() * 4;
-          const shift = (Math.random() - 0.5) * 20;
-          ctx.fillStyle = 'rgba(255, 255, 255, 0.04)';
+          const shift = (Math.random() - 0.5) * 20 * distortion;
+          ctx.fillStyle = `rgba(255, 255, 255, ${0.04 * distortion})`;
           ctx.fillRect(shift, y, canvas.width, h);
         }
       }

--- a/src/components/player/VHSPlayer.tsx
+++ b/src/components/player/VHSPlayer.tsx
@@ -14,7 +14,7 @@ const MIN_CONTENT_LENGTH = 500;
 export type AudioTrack = 'vf' | 'vo';
 
 // Rewind state machine
-type RewindPhase = 'none' | 'prompt' | 'rewinding' | 'complete';
+type RewindPhase = 'none' | 'prompt' | 'rewinding';
 
 type AirPlayVideoElement = HTMLVideoElement & {
   webkitShowPlaybackTargetPicker?: () => void;
@@ -44,20 +44,31 @@ export function VHSPlayer() {
   const [isAirPlayConnected, setIsAirPlayConnected] = useState(false);
   const [showMobileRemotePrompt, setShowMobileRemotePrompt] = useState(false);
 
+  // Overlay auto-hide (4s inactivity)
+  const [overlayVisible, setOverlayVisible] = useState(true);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // FF/RW state
   const [ffSpeed, setFfSpeed] = useState(0); // 0=off, 2=x2, 4=x4
   const rwIntervalRef = useRef<number | null>(null);
   const rwSpeedRef = useRef(0);
+  const rwCleanupRef = useRef<(() => void) | null>(null);
+  // Guard flag to prevent onPause/onPlay handlers from interfering during FF/RW→play transition
+  const isTransitioningRef = useRef(false);
 
-  // Rewind animation state
+  // Rewind animation state (end-of-film rewind)
   const [rewindPhase, setRewindPhase] = useState<RewindPhase>('none');
   const [rewindProgress, setRewindProgress] = useState(0);
   const rewindStartRef = useRef(0);
   const rewindRafRef = useRef<number | null>(null);
+  const [pendingEject, setPendingEject] = useState(false);
+  const [rewindCredited, setRewindCredited] = useState(false);
 
-  // 80% milestone notification
-  const [showMilestone, setShowMilestone] = useState(false);
-  const milestoneShownRef = useRef(false);
+  // Rewind-to-start state (⏮ button)
+  const [rewindingToStart, setRewindingToStart] = useState(false);
+  const [rewindToStartProgress, setRewindToStartProgress] = useState(0);
+  const [rewindToStartCounter, setRewindToStartCounter] = useState(0);
+  const rewindToStartRafRef = useRef<number | null>(null);
 
   // Inline review state (during rewind)
   const [reviewContent, setReviewContentState] = useState('');
@@ -108,6 +119,13 @@ export function VHSPlayer() {
     return streamingUrls.vf || streamingUrls.vo || rental?.videoUrl || '';
   }, [streamingUrls, audioTrack, hasVF, hasVO, rental?.videoUrl]);
 
+  // Check if 80%+ of the film has been watched
+  const hasReachedMilestone = useCallback(() => {
+    const video = videoRef.current;
+    if (!video || !video.duration) return false;
+    return video.currentTime / video.duration >= 0.8;
+  }, []);
+
   const openMirroringFallback = useCallback((context: 'generic' | 'cast' | 'airplay' = 'generic') => {
     setMirroringContext(context);
     setShowMirroringHelp(true);
@@ -135,16 +153,77 @@ export function VHSPlayer() {
     }
   }, [audioTrack]);
 
+  // Resume from saved position when player opens
+  useEffect(() => {
+    if (!isPlayerOpen || !rental?.watchPosition) return;
+    const video = videoRef.current;
+    if (!video) return;
+
+    const handleCanPlay = () => {
+      if (rental.watchPosition > 0 && video.currentTime < 1) {
+        video.currentTime = rental.watchPosition;
+      }
+    };
+
+    video.addEventListener('canplay', handleCanPlay, { once: true });
+    return () => video.removeEventListener('canplay', handleCanPlay);
+  }, [isPlayerOpen, rental?.watchPosition]);
+
   // ===== FF/RW Logic =====
 
-  // Stop any active rewind interval
+  // Stop any active rewind RAF loop + clean up seeked listener
   const stopRW = useCallback(() => {
     if (rwIntervalRef.current !== null) {
-      clearInterval(rwIntervalRef.current);
+      cancelAnimationFrame(rwIntervalRef.current);
       rwIntervalRef.current = null;
     }
+    rwCleanupRef.current?.();
+    rwCleanupRef.current = null;
     rwSpeedRef.current = 0;
   }, []);
+
+  // Resume play after RW/FF — pause first for clean decoder state
+  const resumePlayFromRW = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    // Set transition flag to suppress onPause/onPlay event handlers
+    isTransitioningRef.current = true;
+
+    stopRW();
+    video.pause(); // Pause first — needed for FF where video is still playing at high speed
+    video.playbackRate = 1;
+    setFfSpeed(0);
+    setShowBlueScreen(false);
+
+    // Force seek to nearest keyframe, then wait for decoder
+    const pos = video.currentTime;
+    video.currentTime = pos;
+
+    const resume = () => {
+      video.play().then(() => {
+        isTransitioningRef.current = false;
+        setPlayerState('playing');
+      }).catch(() => {
+        isTransitioningRef.current = false;
+        setPlayerState('paused');
+      });
+    };
+
+    const onSeeked = () => {
+      video.removeEventListener('seeked', onSeeked);
+      resume();
+    };
+    video.addEventListener('seeked', onSeeked, { once: true });
+
+    // Unconditional fallback if seeked never fires (already at exact position)
+    setTimeout(() => {
+      video.removeEventListener('seeked', onSeeked);
+      if (isTransitioningRef.current) {
+        resume();
+      }
+    }, 500);
+  }, [stopRW]);
 
   // FF cycle: off → x2 → x4 → off
   const handleFFCycle = useCallback(() => {
@@ -155,21 +234,21 @@ export function VHSPlayer() {
     stopRW();
 
     const nextSpeed = ffSpeed === 0 ? 2 : ffSpeed === 2 ? 4 : 0;
-    setFfSpeed(nextSpeed);
 
     if (nextSpeed > 0) {
+      setFfSpeed(nextSpeed);
       video.playbackRate = nextSpeed;
       if (video.paused) video.play();
       setPlayerState('fastforwarding');
       setShowBlueScreen(false);
     } else {
-      video.playbackRate = 1;
-      setPlayerState(video.paused ? 'paused' : 'playing');
+      // Returning to normal — use proper resync
+      resumePlayFromRW();
     }
-  }, [ffSpeed, stopRW]);
+  }, [ffSpeed, stopRW, resumePlayFromRW]);
 
   // RW cycle: off → x2 → x4 → off
-  // HTML5 video doesn't support negative playbackRate, so we use an interval
+  // Seek-chained reverse: seek → wait for seeked → seek again (as fast as decoder allows)
   const handleRWCycle = useCallback(() => {
     const video = videoRef.current;
     if (!video) return;
@@ -180,7 +259,7 @@ export function VHSPlayer() {
     const currentRWSpeed = rwSpeedRef.current;
     const nextSpeed = currentRWSpeed === 0 ? 2 : currentRWSpeed === 2 ? 4 : 0;
 
-    // Stop existing interval
+    // Stop existing loop
     stopRW();
 
     setFfSpeed(nextSpeed);
@@ -191,44 +270,138 @@ export function VHSPlayer() {
       setPlayerState('rewinding');
       setShowBlueScreen(false);
 
-      // Manual rewind via interval (60fps)
-      rwIntervalRef.current = window.setInterval(() => {
+      let lastSeekTs = performance.now();
+
+      const seekNext = () => {
         const v = videoRef.current;
-        if (!v) return;
-        v.currentTime = Math.max(0, v.currentTime - rwSpeedRef.current * (1 / 30));
-        if (v.currentTime <= 0) {
+        if (!v || rwSpeedRef.current === 0) return;
+
+        const now = performance.now();
+        const elapsed = (now - lastSeekTs) / 1000;
+        const step = rwSpeedRef.current * Math.max(elapsed, 0.1);
+        const newTime = Math.max(0, v.currentTime - step);
+        lastSeekTs = now;
+
+        if (newTime <= 0) {
+          v.currentTime = 0;
           stopRW();
           setFfSpeed(0);
           setPlayerState('paused');
+          return;
         }
-      }, 1000 / 30);
-    } else {
-      setPlayerState(video.paused ? 'paused' : 'playing');
-    }
-  }, [stopRW]);
 
-  // Stop button: pause + reset to 0 + blue screen
+        v.currentTime = newTime;
+        // seeked event will chain the next seek
+      };
+
+      const onSeeked = () => {
+        if (rwSpeedRef.current === 0) return;
+        rwIntervalRef.current = requestAnimationFrame(seekNext);
+      };
+
+      video.addEventListener('seeked', onSeeked);
+      rwCleanupRef.current = () => video.removeEventListener('seeked', onSeeked);
+
+      // Kick off first seek
+      rwIntervalRef.current = requestAnimationFrame(seekNext);
+    } else {
+      resumePlayFromRW();
+    }
+  }, [stopRW, resumePlayFromRW]);
+
+  // Stop button: save position + pause + blue screen (or rewind prompt at 80%+)
   const handleStop = useCallback(() => {
     const video = videoRef.current;
     if (!video) return;
 
+    // Save current position before stopping
+    if (currentPlayingFilm && video.duration > 0) {
+      const progress = Math.round((video.currentTime / video.duration) * 100);
+      api.rentals.updateProgress(currentPlayingFilm, progress, video.currentTime).catch(() => {});
+    }
+
     stopRW();
     video.pause();
-    video.currentTime = 0;
     video.playbackRate = 1;
     setFfSpeed(0);
-    setPlayerState('paused');
-    setShowBlueScreen(true);
-  }, [stopRW]);
 
-  // Eject: close player
-  const handleEject = useCallback(() => {
-    stopRW();
-    if (rewindRafRef.current !== null) {
-      cancelAnimationFrame(rewindRafRef.current);
+    // At 80%+ and not yet rewound → rewind prompt
+    if (hasReachedMilestone() && !rental?.rewindClaimed) {
+      setPendingEject(false);
+      setRewindPhase('prompt');
+    } else {
+      setPlayerState('paused');
+      setShowBlueScreen(true);
     }
-    closePlayer();
-  }, [closePlayer, stopRW]);
+  }, [stopRW, currentPlayingFilm, hasReachedMilestone, rental?.rewindClaimed]);
+
+  // Rewind to start (⏮) — simulates VHS tape rewind with proportional duration
+  const handleRewindToStart = useCallback(() => {
+    const video = videoRef.current;
+    if (!video || video.currentTime < 1 || rewindingToStart) return;
+
+    stopRW();
+    video.pause();
+    video.playbackRate = 1;
+    setFfSpeed(0);
+    setPlayerState('rewinding');
+    setShowBlueScreen(false);
+    setRewindingToStart(true);
+
+    const startTime = video.currentTime;
+    const startCounter = Math.floor((startTime / (video.duration || 1)) * 9999);
+    // Proportional: 2 min (120s) for full film, minimum 1s
+    const rewindDurationMs = Math.max(1000, (startTime / (video.duration || 1)) * 120000);
+    const animStart = performance.now();
+
+    const animate = () => {
+      const elapsed = performance.now() - animStart;
+      const t = Math.min(1, elapsed / rewindDurationMs);
+      const remaining = startTime * (1 - t);
+      video.currentTime = remaining;
+      setRewindToStartProgress(t * 100);
+      setRewindToStartCounter(Math.floor(startCounter * (1 - t)));
+
+      if (t >= 1) {
+        video.currentTime = 0;
+        setRewindingToStart(false);
+        setRewindToStartProgress(0);
+        setRewindToStartCounter(0);
+        setPlayerState('paused');
+        return;
+      }
+      rewindToStartRafRef.current = requestAnimationFrame(animate);
+    };
+
+    rewindToStartRafRef.current = requestAnimationFrame(animate);
+  }, [rewindingToStart, stopRW]);
+
+  // Eject: save position + close player (or rewind prompt at 80%+)
+  const handleEject = useCallback(() => {
+    const video = videoRef.current;
+    if (video && currentPlayingFilm && video.duration > 0) {
+      const progress = Math.round((video.currentTime / video.duration) * 100);
+      api.rentals.updateProgress(currentPlayingFilm, progress, video.currentTime).catch(() => {});
+    }
+    stopRW();
+
+    // At 80%+ and not yet rewound → rewind prompt before ejecting
+    if (hasReachedMilestone() && !rental?.rewindClaimed) {
+      const v = videoRef.current;
+      if (v) v.pause();
+      setPendingEject(true);
+      setRewindPhase('prompt');
+    } else {
+      if (rewindRafRef.current !== null) {
+        cancelAnimationFrame(rewindRafRef.current);
+      }
+      if (rewindToStartRafRef.current !== null) {
+        cancelAnimationFrame(rewindToStartRafRef.current);
+      }
+      setRewindingToStart(false);
+      closePlayer();
+    }
+  }, [closePlayer, stopRW, currentPlayingFilm, hasReachedMilestone, rental?.rewindClaimed]);
 
   // Clean up intervals on unmount
   useEffect(() => {
@@ -237,8 +410,35 @@ export function VHSPlayer() {
       if (rewindRafRef.current !== null) {
         cancelAnimationFrame(rewindRafRef.current);
       }
+      if (rewindToStartRafRef.current !== null) {
+        cancelAnimationFrame(rewindToStartRafRef.current);
+      }
     };
   }, [stopRW]);
+
+  // Dismiss rewind prompt without rewinding (STOP flow → blue screen)
+  const dismissRewindPrompt = useCallback(() => {
+    setRewindPhase('none');
+    setPlayerState('paused');
+    setShowBlueScreen(true);
+  }, []);
+
+  // Close rewind modal (during or after rewind)
+  const closeRewindModal = useCallback(() => {
+    if (rewindRafRef.current !== null) {
+      cancelAnimationFrame(rewindRafRef.current);
+      rewindRafRef.current = null;
+    }
+    setRewindPhase('none');
+    setRewindProgress(0);
+    setRewindCredited(false);
+    if (pendingEject) {
+      closePlayer();
+    } else {
+      setPlayerState('paused');
+      setShowBlueScreen(true);
+    }
+  }, [pendingEject, closePlayer]);
 
   // ===== Keyboard Controls (VCR style) =====
   useEffect(() => {
@@ -248,17 +448,37 @@ export function VHSPlayer() {
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'TEXTAREA' || tag === 'INPUT') return;
 
+      // Block most keys during rewind-to-start or rewind flow (only Escape allowed)
+      if (rewindingToStart) {
+        if (e.key === 'Escape') handleEject();
+        return;
+      }
+      if (rewindPhase !== 'none') {
+        if (e.key === 'Escape') {
+          if (rewindPhase === 'prompt') {
+            if (pendingEject) {
+              closePlayer();
+            } else {
+              setRewindPhase('none');
+              setPlayerState('paused');
+              setShowBlueScreen(true);
+            }
+          } else if (rewindPhase === 'rewinding') {
+            closeRewindModal();
+          }
+        }
+        return;
+      }
+
       const video = videoRef.current;
       if (!video) return;
 
       switch (e.key) {
         case ' ':
           e.preventDefault();
-          // Reset speed modes
-          stopRW();
-          video.playbackRate = 1;
-          setFfSpeed(0);
-          if (video.paused) {
+          if (playerState === 'rewinding' || playerState === 'fastforwarding') {
+            resumePlayFromRW();
+          } else if (video.paused) {
             video.play();
             setPlayerState('playing');
             setShowBlueScreen(false);
@@ -307,6 +527,10 @@ export function VHSPlayer() {
             setShowSubtitles(prev => !prev);
           }
           break;
+        case 'r':
+        case 'R':
+          handleRewindToStart();
+          break;
         case 'Escape':
           handleEject();
           break;
@@ -315,7 +539,7 @@ export function VHSPlayer() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isPlayerOpen, handleEject, handleStop, handleFFCycle, handleRWCycle, hasVF, hasVO, hasSubtitles, audioTrack, handleAudioTrackChange, stopRW]);
+  }, [isPlayerOpen, playerState, rewindingToStart, rewindPhase, pendingEject, closePlayer, closeRewindModal, handleEject, handleStop, handleFFCycle, handleRWCycle, handleRewindToStart, resumePlayFromRW, hasVF, hasVO, hasSubtitles, audioTrack, handleAudioTrackChange, stopRW]);
 
   // ===== Remote playback (AirPlay) =====
   useEffect(() => {
@@ -441,14 +665,8 @@ export function VHSPlayer() {
       if (!video || video.duration === 0 || video.paused) return;
 
       const progress = Math.round((video.currentTime / video.duration) * 100);
-      api.rentals.updateProgress(currentPlayingFilm, progress).catch(() => {});
+      api.rentals.updateProgress(currentPlayingFilm, progress, video.currentTime).catch(() => {});
 
-      // 80% milestone notification
-      if (progress >= 80 && !milestoneShownRef.current) {
-        milestoneShownRef.current = true;
-        setShowMilestone(true);
-        setTimeout(() => setShowMilestone(false), 3000);
-      }
     }, 30000);
 
     return () => clearInterval(interval);
@@ -462,21 +680,28 @@ export function VHSPlayer() {
     const handleEnded = () => {
       stopRW();
       setFfSpeed(0);
-      // Send final progress (100%)
+      // Send final progress (100%) + reset position to 0
       if (currentPlayingFilm) {
-        api.rentals.updateProgress(currentPlayingFilm, 100).catch(() => {});
+        api.rentals.updateProgress(currentPlayingFilm, 100, 0).catch(() => {});
       }
-      setRewindPhase('prompt');
+      // Same flow as eject — pendingEject=true since film ended
+      if (!rental?.rewindClaimed) {
+        setPendingEject(true);
+        setRewindPhase('prompt');
+      } else {
+        closePlayer();
+      }
     };
 
     video.addEventListener('ended', handleEnded);
     return () => video.removeEventListener('ended', handleEnded);
-  }, [currentPlayingFilm, stopRW]);
+  }, [currentPlayingFilm, stopRW, rental?.rewindClaimed, closePlayer]);
 
   // ===== Rewind Animation =====
   const startRewind = useCallback(() => {
     setRewindPhase('rewinding');
     setRewindProgress(0);
+    setRewindCredited(false);
     rewindStartRef.current = performance.now();
 
     const video = videoRef.current;
@@ -490,13 +715,8 @@ export function VHSPlayer() {
       setRewindProgress(progress);
 
       if (progress >= 100) {
-        // Don't transition to complete if user is writing a review
-        if (reviewContentRef.current.length > 0) {
-          setRewindProgress(100);
-          return;
-        }
-        setRewindPhase('complete');
-        // Claim rewind credit
+        // Claim rewind credit inline — no phase transition
+        setRewindCredited(true);
         if (currentPlayingFilm) {
           api.rentals.claimRewind(currentPlayingFilm)
             .then(() => { fetchMe(); })
@@ -549,22 +769,7 @@ export function VHSPlayer() {
     }
   }, [currentPlayingFilm, isAuthenticated, reviewContent, ratingDirection, ratingScreenplay, ratingActing, addCredits]);
 
-  // Transition to complete when rewind done + review finished or cleared
-  useEffect(() => {
-    if (rewindPhase !== 'rewinding' || rewindProgress < 100) return;
-    if (reviewContent.length > 0 && !reviewSuccess) return;
-    // Small delay after success so user sees the confirmation
-    const delay = reviewSuccess ? 2000 : 0;
-    const timer = setTimeout(() => {
-      setRewindPhase('complete');
-      if (currentPlayingFilm) {
-        api.rentals.claimRewind(currentPlayingFilm)
-          .then(() => { fetchMe(); })
-          .catch(() => {});
-      }
-    }, delay);
-    return () => clearTimeout(timer);
-  }, [rewindPhase, rewindProgress, reviewContent, reviewSuccess, currentPlayingFilm, fetchMe]);
+
 
   // Reset state when player closes/opens
   useEffect(() => {
@@ -582,8 +787,8 @@ export function VHSPlayer() {
       setShowMobileRemotePrompt(false);
       setRewindPhase('none');
       setRewindProgress(0);
-      milestoneShownRef.current = false;
-      setShowMilestone(false);
+      setPendingEject(false);
+      setRewindCredited(false);
       // Reset review state
       setReviewContent('');
       setRatingDirection(3);
@@ -592,17 +797,58 @@ export function VHSPlayer() {
       setReviewError(null);
       setReviewSuccess(false);
       setReviewData(null);
+      // Reset rewind-to-start
+      if (rewindToStartRafRef.current !== null) cancelAnimationFrame(rewindToStartRafRef.current);
+      setRewindingToStart(false);
+      setRewindToStartProgress(0);
+      setRewindToStartCounter(0);
+      // Reset overlay
+      setOverlayVisible(true);
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
     }
   }, [isPlayerOpen, stopRW]);
+
+  // ===== Overlay auto-hide (4s inactivity) =====
+  const resetIdleTimer = useCallback(() => {
+    setOverlayVisible(true);
+    if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    idleTimerRef.current = setTimeout(() => {
+      setOverlayVisible(false);
+    }, 4000);
+  }, []);
+
+  useEffect(() => {
+    if (!isPlayerOpen || rewindPhase !== 'none' || rewindingToStart) return;
+
+    const onActivity = () => resetIdleTimer();
+
+    window.addEventListener('mousemove', onActivity);
+    window.addEventListener('touchstart', onActivity);
+    window.addEventListener('keydown', onActivity);
+
+    // Start initial timer
+    resetIdleTimer();
+
+    return () => {
+      window.removeEventListener('mousemove', onActivity);
+      window.removeEventListener('touchstart', onActivity);
+      window.removeEventListener('keydown', onActivity);
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    };
+  }, [isPlayerOpen, rewindPhase, rewindingToStart, resetIdleTimer]);
 
   if (!isPlayerOpen || !rental) return null;
   const connectedTvLabel = castDeviceName || (isAirPlayConnected ? 'TV AirPlay connectée' : null);
 
   return (
-    <div className={styles.player}>
+    <div className={styles.player} style={!overlayVisible && rewindPhase === 'none' ? { cursor: 'none' } : undefined}>
       {/* Film title header */}
       {currentFilm && (
-        <div className={styles.header}>
+        <div className={styles.header} style={{
+          opacity: overlayVisible ? 1 : 0,
+          transition: 'opacity 0.4s',
+          pointerEvents: overlayVisible ? 'auto' : 'none',
+        }}>
           <span className={styles.filmTitle}>{currentFilm.title}</span>
           <span className={styles.trackIndicator}>
             {audioTrack.toUpperCase()}
@@ -618,10 +864,17 @@ export function VHSPlayer() {
         className={styles.video}
         autoPlay
         playsInline
-        onPlay={() => { setPlayerState('playing'); setShowBlueScreen(false); }}
+        onPlay={() => {
+          if (!isTransitioningRef.current) {
+            setPlayerState('playing');
+            setShowBlueScreen(false);
+          }
+        }}
         onPause={() => {
-          // Don't override rewinding state
-          if (playerState !== 'rewinding') setPlayerState('paused');
+          // Don't override rewinding/fastforwarding state or transition in progress
+          if (!isTransitioningRef.current && playerState !== 'rewinding' && playerState !== 'fastforwarding') {
+            setPlayerState('paused');
+          }
         }}
       >
         <source src={videoUrl} type="video/mp4" />
@@ -645,34 +898,11 @@ export function VHSPlayer() {
         </div>
       )}
 
-      {/* 80% milestone notification */}
-      {showMilestone && (
-        <div style={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          zIndex: 30,
-          background: 'rgba(0, 0, 0, 0.88)',
-          border: '2px solid #00e5ff',
-          borderRadius: 10,
-          padding: '24px 32px',
-          textAlign: 'center',
-          fontFamily: "'Orbitron', monospace",
-          boxShadow: '0 0 30px rgba(0, 229, 255, 0.3)',
-          pointerEvents: 'none',
-        }}>
-          <div style={{ color: '#00e5ff', fontSize: '1.1rem', marginBottom: 10, letterSpacing: 2 }}>
-            80% VISIONNE
-          </div>
-          <div style={{ color: 'rgba(255,255,255,0.8)', fontSize: '0.82rem', lineHeight: 1.6 }}>
-            Rembobinez pour +1 credit.<br />
-            Laissez une critique pour +1 credit.
-          </div>
-        </div>
-      )}
-
-      <div className={styles.rentalTimer}>
+      <div className={styles.rentalTimer} style={{
+        opacity: overlayVisible ? 1 : 0,
+        transition: 'opacity 0.4s',
+        pointerEvents: overlayVisible ? 'auto' : 'none',
+      }}>
         <RentalTimer expiresAt={rental.expiresAt} />
       </div>
 
@@ -695,26 +925,104 @@ export function VHSPlayer() {
         </div>
       )}
 
-      {/* ===== Rewind Prompt (film ended) ===== */}
+      {/* ===== Rewind to Start Overlay ===== */}
+      {rewindingToStart && (
+        <div className={styles.rewindOverlay}>
+          <div className={styles.reelContainer}>
+            <svg viewBox="0 0 200 80" className={styles.reelSvg}>
+              <circle
+                cx="50" cy="40"
+                r={8 + (rewindToStartProgress / 100) * 22}
+                fill="none"
+                stroke="#00fff7"
+                strokeWidth="2"
+                opacity="0.9"
+              />
+              <circle cx="50" cy="40" r="5" fill="#00fff7" opacity="0.3" />
+              <circle
+                cx="150" cy="40"
+                r={30 - (rewindToStartProgress / 100) * 22}
+                fill="none"
+                stroke="#00fff7"
+                strokeWidth="2"
+                opacity="0.9"
+              />
+              <circle cx="150" cy="40" r="5" fill="#00fff7" opacity="0.3" />
+              <line
+                x1={50 + 8 + (rewindToStartProgress / 100) * 22}
+                y1="40"
+                x2={150 - 30 + (rewindToStartProgress / 100) * 22}
+                y2="40"
+                stroke="#00fff7"
+                strokeWidth="1"
+                opacity="0.4"
+              />
+            </svg>
+          </div>
+          <div className={styles.rewindTapeCounter}>
+            {String(rewindToStartCounter).padStart(4, '0')}
+          </div>
+          <div className={styles.rewindBarContainer}>
+            <div className={styles.rewindBarFill} style={{ width: `${rewindToStartProgress}%` }} />
+          </div>
+          <div className={styles.rewindLabel}>REMBOBINAGE...</div>
+        </div>
+      )}
+
+      {/* ===== Rewind Prompt (STOP/EJECT at 80%+ or film ended) ===== */}
       {rewindPhase === 'prompt' && (
         <div className={styles.rewindOverlay}>
           <div className={styles.rewindPromptText}>
             BE KIND<br />REWIND
           </div>
+          <div style={{ color: 'rgba(255,255,255,0.7)', fontSize: '0.9rem', marginBottom: 16, fontFamily: "'Orbitron', monospace", letterSpacing: 1 }}>
+            {pendingEject ? 'Rembobiner avant de partir ? +1 crédit' : 'Rembobiner pour +1 crédit ?'}
+          </div>
           <div className={styles.rewindButtons}>
             <button onClick={startRewind} className={styles.rewindBtn}>
               ◀◀ REMBOBINER
             </button>
-            <button onClick={handleEject} className={styles.ejectRewindBtn}>
-              ⏏ ÉJECTER SANS REMBOBINER
-            </button>
+            {pendingEject ? (
+              <button onClick={closePlayer} className={styles.ejectRewindBtn}>
+                ⏏ ÉJECTER
+              </button>
+            ) : (
+              <button onClick={dismissRewindPrompt} className={styles.ejectRewindBtn}>
+                NON MERCI
+              </button>
+            )}
           </div>
         </div>
       )}
 
-      {/* ===== Rewind Animation + Review ===== */}
+      {/* ===== Rewind Animation + Review Modal ===== */}
       {rewindPhase === 'rewinding' && (
         <div className={styles.rewindOverlay} style={{ justifyContent: 'flex-start', paddingTop: '3vh' }}>
+          {/* Close button */}
+          <button
+            onClick={closeRewindModal}
+            style={{
+              position: 'absolute',
+              top: 16,
+              right: 20,
+              background: 'none',
+              border: '1px solid rgba(255,255,255,0.3)',
+              color: 'rgba(255,255,255,0.7)',
+              fontSize: '1.4rem',
+              cursor: 'pointer',
+              width: 36,
+              height: 36,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 4,
+              zIndex: 10,
+            }}
+            title="Fermer"
+          >
+            ✕
+          </button>
+
           {/* VHS Reel Animation */}
           <div className={styles.reelContainer}>
             <svg viewBox="0 0 200 80" className={styles.reelSvg}>
@@ -758,7 +1066,16 @@ export function VHSPlayer() {
           <div className={styles.rewindBarContainer}>
             <div className={styles.rewindBarFill} style={{ width: `${rewindProgress}%` }} />
           </div>
-          <div className={styles.rewindLabel}>REMBOBINAGE EN COURS...</div>
+          <div className={styles.rewindLabel}>
+            {rewindCredited ? 'REMBOBINAGE TERMINÉ' : 'REMBOBINAGE EN COURS...'}
+          </div>
+
+          {/* Credit claimed message */}
+          {rewindCredited && (
+            <div className={styles.rewindReviewSuccess} style={{ marginTop: 8, marginBottom: 4 }}>
+              <span>✓</span> MERCI ! <span className={styles.rewindCreditBonus}>+1 CRÉDIT</span>
+            </div>
+          )}
 
           {/* Review form */}
           <div className={styles.rewindReviewSection}>
@@ -830,17 +1147,6 @@ export function VHSPlayer() {
         </div>
       )}
 
-      {/* ===== Rewind Complete ===== */}
-      {rewindPhase === 'complete' && (
-        <div className={styles.rewindOverlay}>
-          <div className={styles.rewindCompleteIcon}>✓</div>
-          <div className={styles.creditMessage}>MERCI ! +1 CRÉDIT</div>
-          <button onClick={handleEject} className={styles.rewindBtn}>
-            ⏏ ÉJECTER
-          </button>
-        </div>
-      )}
-
       {showMirroringHelp && (
         <div className={styles.mirroringOverlay}>
           <div className={styles.mirroringPanel}>
@@ -878,7 +1184,12 @@ export function VHSPlayer() {
       )}
 
       {/* VCR Controls — only show when not in rewind sequence */}
-      {rewindPhase === 'none' && (
+      {rewindPhase === 'none' && !rewindingToStart && (
+        <div style={{
+          opacity: overlayVisible ? 1 : 0,
+          transition: 'opacity 0.4s',
+          pointerEvents: overlayVisible ? 'auto' : 'none',
+        }}>
         <VHSControls
           videoRef={videoRef}
           playerState={playerState}
@@ -888,6 +1199,8 @@ export function VHSPlayer() {
           ffSpeed={ffSpeed}
           onFFCycle={handleFFCycle}
           onRWCycle={handleRWCycle}
+          onRewindToStart={handleRewindToStart}
+          onResumeFromRW={resumePlayFromRW}
           audioTrack={audioTrack}
           onAudioTrackChange={handleAudioTrackChange}
           showSubtitles={showSubtitles}
@@ -907,6 +1220,7 @@ export function VHSPlayer() {
           isAirPlayConnected={isAirPlayConnected}
           remoteError={remoteError}
         />
+        </div>
       )}
     </div>
   );

--- a/src/components/review/ReviewModal.tsx
+++ b/src/components/review/ReviewModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useStore } from '../../store';
-import api, { type ReviewsResponse } from '../../api';
+import api, { type ReviewsResponse, type ReviewWithUser } from '../../api';
 import type { Film } from '../../types';
 import styles from './ReviewModal.module.css';
 
@@ -23,8 +23,10 @@ export function ReviewModal({ isOpen, onClose, film }: ReviewModalProps) {
   const [success, setSuccess] = useState(false);
   const [reviewsData, setReviewsData] = useState<ReviewsResponse | null>(null);
   const [loading, setLoading] = useState(false);
+  const [editMode, setEditMode] = useState(false);
 
   const isAuthenticated = useStore(state => state.isAuthenticated);
+  const authUser = useStore(state => state.authUser);
   const addCredits = useStore(state => state.addCredits);
 
   // Load reviews and check if user can review
@@ -33,13 +35,24 @@ export function ReviewModal({ isOpen, onClose, film }: ReviewModalProps) {
       setLoading(true);
       api.reviews.getByFilm(film.id).then((data) => {
         setReviewsData(data);
+        // Check if current user already has a review → edit mode
+        if (authUser && data.reviews.length > 0) {
+          const userReview = data.reviews.find((r: ReviewWithUser) => r.user_id === authUser.id);
+          if (userReview) {
+            setEditMode(true);
+            setContent(userReview.content);
+            setRatingDirection(userReview.rating_direction);
+            setRatingScreenplay(userReview.rating_screenplay);
+            setRatingActing(userReview.rating_acting);
+          }
+        }
         setLoading(false);
       }).catch((err) => {
         console.error(err);
         setLoading(false);
       });
     }
-  }, [isOpen, film]);
+  }, [isOpen, film, authUser]);
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
@@ -54,14 +67,19 @@ export function ReviewModal({ isOpen, onClose, film }: ReviewModalProps) {
     setError(null);
 
     try {
-      await api.reviews.create(film.id, {
+      const reviewData = {
         content,
         rating_direction: ratingDirection,
         rating_screenplay: ratingScreenplay,
         rating_acting: ratingActing,
-      });
+      };
+      if (editMode) {
+        await api.reviews.update(film.id, reviewData);
+      } else {
+        await api.reviews.create(film.id, reviewData);
+        addCredits(1); // +1 credit only on creation
+      }
       setSuccess(true);
-      addCredits(1); // +1 credit locally
       setTimeout(() => {
         handleClose();
       }, 2000);
@@ -70,7 +88,7 @@ export function ReviewModal({ isOpen, onClose, film }: ReviewModalProps) {
     } finally {
       setSubmitting(false);
     }
-  }, [film, isAuthenticated, content, ratingDirection, ratingScreenplay, ratingActing, addCredits]);
+  }, [film, isAuthenticated, content, ratingDirection, ratingScreenplay, ratingActing, addCredits, editMode]);
 
   const handleClose = useCallback(() => {
     setContent('');
@@ -80,19 +98,20 @@ export function ReviewModal({ isOpen, onClose, film }: ReviewModalProps) {
     setError(null);
     setSuccess(false);
     setReviewsData(null);
+    setEditMode(false);
     onClose();
   }, [onClose]);
 
   if (!isOpen || !film) return null;
 
-  const canReview = reviewsData?.canReview?.allowed ?? false;
-  const canReviewReason = reviewsData?.canReview?.reason;
+  const canReview = editMode || (reviewsData?.canReview?.allowed ?? false);
+  const canReviewReason = editMode ? undefined : reviewsData?.canReview?.reason;
 
   const content_ui = (
     <div className={styles.overlay} onClick={handleClose}>
       <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
         <div className={styles.header}>
-          CRITIQUER: {film.title.toUpperCase().substring(0, 30)}
+          {editMode ? 'MODIFIER' : 'CRITIQUER'}: {film.title.toUpperCase().substring(0, 30)}
           <span className={styles.cursor} />
         </div>
 
@@ -102,8 +121,8 @@ export function ReviewModal({ isOpen, onClose, film }: ReviewModalProps) {
           ) : success ? (
             <div className={styles.successBox}>
               <div className={styles.checkmark}>✓</div>
-              <div>CRITIQUE PUBLIEE !</div>
-              <div className={styles.creditBonus}>+1 CREDIT</div>
+              <div>{editMode ? 'CRITIQUE MODIFIEE !' : 'CRITIQUE PUBLIEE !'}</div>
+              {!editMode && <div className={styles.creditBonus}>+1 CREDIT</div>}
             </div>
           ) : !isAuthenticated ? (
             <div className={styles.notAllowed}>
@@ -185,7 +204,7 @@ export function ReviewModal({ isOpen, onClose, film }: ReviewModalProps) {
                 className={styles.submitButton}
                 disabled={submitting || content.length < MIN_CONTENT_LENGTH}
               >
-                {submitting ? 'PUBLICATION...' : 'PUBLIER (+1 CREDIT)'}
+                {submitting ? 'PUBLICATION...' : editMode ? 'MODIFIER' : 'PUBLIER (+1 CREDIT)'}
               </button>
             </form>
           )}
@@ -217,7 +236,7 @@ export function ReviewModal({ isOpen, onClose, film }: ReviewModalProps) {
         </div>
 
         <div className={styles.footer}>
-          [ESC] Fermer | Critique = +1 credit
+          [ESC] Fermer{editMode ? '' : ' | Critique = +1 credit'}
         </div>
       </div>
     </div>

--- a/src/components/videoclub/VHSCaseOverlay.tsx
+++ b/src/components/videoclub/VHSCaseOverlay.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useDrag } from "@use-gesture/react";
 import { useStore } from "../../store";
 import { tmdb, type TMDBVideo } from "../../services/tmdb";
-import api, { type FilmWithRentalStatus } from "../../api";
+import api, { type FilmWithRentalStatus, type FilmRatings } from "../../api";
 import { AuthModal } from "../auth/AuthModal";
 import { ReviewModal } from "../review/ReviewModal";
 import {
@@ -350,6 +350,8 @@ export function VHSCaseOverlay({ film, isOpen, onClose }: VHSCaseOverlayProps) {
   const storeExtendRental = useStore((state) => state.extendRental);
   const fetchMe = useStore((state) => state.fetchMe);
   const openPlayer = useStore((state) => state.openPlayer);
+  const setSitting = useStore((state) => state.setSitting);
+  const requestPointerUnlock = useStore((state) => state.requestPointerUnlock);
   const showManager = useStore((state) => state.showManager);
   const pushEvent = useStore((state) => state.pushEvent);
   const hasSeenSwipeHint = useStore((state) => state.hasSeenVHSSwipeHint);
@@ -484,6 +486,9 @@ export function VHSCaseOverlay({ film, isOpen, onClose }: VHSCaseOverlayProps) {
   const [budget, setBudget] = useState<number>(0);
   const [revenue, setRevenue] = useState<number>(0);
 
+  // Club review ratings (average from user reviews)
+  const [clubRatings, setClubRatings] = useState<FilmRatings | null>(null);
+
   // Detailed credits + person modal
   const [detailedCredits, setDetailedCredits] = useState<DetailedCredits | null>(null);
   const [selectedPerson, setSelectedPerson] = useState<CreditPerson | null>(null);
@@ -528,7 +533,7 @@ export function VHSCaseOverlay({ film, isOpen, onClose }: VHSCaseOverlayProps) {
     }).catch(() => {});
   }, [isOpen, film?.tmdb_id]);
 
-  // Fetch detailed credits, certification, and TMDB reviews when overlay opens
+  // Fetch detailed credits, certification, TMDB reviews, and club ratings when overlay opens
   useEffect(() => {
     if (!isOpen || !film?.tmdb_id) {
       setDetailedCredits(null);
@@ -536,6 +541,7 @@ export function VHSCaseOverlay({ film, isOpen, onClose }: VHSCaseOverlayProps) {
       setTmdbReviews([]);
       setBudget(0);
       setRevenue(0);
+      setClubRatings(null);
       return;
     }
     const id = film.tmdb_id;
@@ -543,7 +549,11 @@ export function VHSCaseOverlay({ film, isOpen, onClose }: VHSCaseOverlayProps) {
     tmdb.getCertification(id).then(c => { console.log(`[VHS] Certification for tmdb_id=${id}:`, JSON.stringify(c)); setCertification(c); }).catch(e => console.warn('Certification fetch failed:', e));
     tmdb.getReviews(id).then(setTmdbReviews).catch(e => console.warn('Reviews fetch failed:', e));
     tmdb.getFilm(id).then(d => { setBudget((d as any).budget || 0); setRevenue((d as any).revenue || 0); }).catch(() => {});
-  }, [isOpen, film?.tmdb_id]);
+    // Fetch club review ratings
+    if (film.id) {
+      api.reviews.getByFilm(film.id).then(data => setClubRatings(data.ratings)).catch(() => {});
+    }
+  }, [isOpen, film?.tmdb_id, film?.id]);
 
   // Fetch person detail when a person is selected
   useEffect(() => {
@@ -584,6 +594,7 @@ export function VHSCaseOverlay({ film, isOpen, onClose }: VHSCaseOverlayProps) {
       setTmdbReviews([]);
       setBudget(0);
       setRevenue(0);
+      setClubRatings(null);
       if (couchPopupTimeoutRef.current) {
         clearTimeout(couchPopupTimeoutRef.current);
         couchPopupTimeoutRef.current = null;
@@ -761,8 +772,10 @@ export function VHSCaseOverlay({ film, isOpen, onClose }: VHSCaseOverlayProps) {
   const handleSitDown = useCallback(() => {
     if (!film) return;
     onClose();
+    setSitting(true);
+    requestPointerUnlock();
     openPlayer(film.id);
-  }, [film, onClose, openPlayer]);
+  }, [film, onClose, openPlayer, setSitting, requestPointerUnlock]);
 
   const handleReturnClick = useCallback(() => {
     setShowReturnConfirm(true);
@@ -1795,6 +1808,18 @@ export function VHSCaseOverlay({ film, isOpen, onClose }: VHSCaseOverlayProps) {
                 }}>
                   ★ {film.vote_average.toFixed(1)}
                 </span>
+                {clubRatings && (
+                  <span style={{
+                    marginLeft: "8px",
+                    fontSize: "0.84rem",
+                    color: "#ffd700",
+                  }}>
+                    ★ {clubRatings.overall.toFixed(1)}
+                    <span style={{ fontSize: "0.68rem", color: "rgba(255,215,0,0.6)", marginLeft: "2px" }}>
+                      ({clubRatings.count})
+                    </span>
+                  </span>
+                )}
               </div>
             </div>
 
@@ -2182,6 +2207,17 @@ export function VHSCaseOverlay({ film, isOpen, onClose }: VHSCaseOverlayProps) {
                 }}
               >
                 ★ {film.vote_average.toFixed(1)}
+                {clubRatings && (
+                  <span
+                    style={{ marginLeft: "10px", color: "#ffd700", fontSize: "0.95rem" }}
+                    title={`Note Zone Club (${clubRatings.count} critique${clubRatings.count > 1 ? 's' : ''})`}
+                  >
+                    ★ {clubRatings.overall.toFixed(1)}
+                    <span style={{ fontSize: "0.75rem", color: "rgba(255,215,0,0.6)", marginLeft: "2px" }}>
+                      ({clubRatings.count})
+                    </span>
+                  </span>
+                )}
                 <span
                   style={{ marginLeft: "12px", color: "rgba(255,255,255,0.5)" }}
                 >
@@ -2445,7 +2481,13 @@ export function VHSCaseOverlay({ film, isOpen, onClose }: VHSCaseOverlayProps) {
       {/* Review Modal */}
       <ReviewModal
         isOpen={showReviewModal}
-        onClose={() => setShowReviewModal(false)}
+        onClose={() => {
+          setShowReviewModal(false);
+          // Refresh club ratings in case a review was submitted
+          if (film?.id) {
+            api.reviews.getByFilm(film.id).then(data => setClubRatings(data.ratings)).catch(() => {});
+          }
+        }}
         film={film}
       />
     </div>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -61,6 +61,7 @@ function apiRentalToRental(apiRental: ApiRentalWithFilm): Rental {
     videoUrl: apiRental.streaming_urls.vf || apiRental.streaming_urls.vo || '',
     streamingUrls: apiRental.streaming_urls,
     watchProgress: apiRental.watch_progress ?? 0,
+    watchPosition: apiRental.watch_position ?? 0,
     watchCompletedAt: apiRental.watch_completed_at ? new Date(apiRental.watch_completed_at).getTime() : null,
     extensionUsed: !!apiRental.extension_used,
     rewindClaimed: !!apiRental.rewind_claimed,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,7 @@ export interface Rental {
   streamingUrls?: StreamingUrls;
   // Gamification fields
   watchProgress: number;             // 0-100
+  watchPosition: number;             // seconds (video currentTime)
   watchCompletedAt: number | null;   // timestamp when 80%+ reached
   extensionUsed: boolean;
   rewindClaimed: boolean;


### PR DESCRIPTION
- Rewind prompt déclenché par STOP/EJECT dès 80% (plus seulement sur ended)
- Modale critique ouverte pendant le rembobinage avec barre de progression
- Crédit attribué à la fin du rembobinage, pendingEject gère fermeture
- Correction bug Player rew > play 
- Suppression notification 80% flottante et phase 'complete' séparée
- Note moyenne des critiques Zone Club affichée à côté du solde (desktop + mobile)
- Modification de critique existante (PUT /api/reviews, pas de crédit sur edit)
- ReviewModal détecte automatiquement la critique de l'utilisateur et pré-remplit