### PR TITLE
fix(security P1): close 4 audit findings

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -5,11 +5,12 @@ import { createSessionToken } from '@/lib/session';
 import { checkRateLimit, getRateLimitKey } from '@/lib/rate-limit';
 
 export async function POST(request: NextRequest) {
-    const rateLimitKey = getRateLimitKey(request, 'login');
-    const retryAfter = checkRateLimit(rateLimitKey, 5, 15 * 60 * 1000);
-    if (retryAfter !== null) {
+    // IP-keyed bucket — defends against a single host hammering the endpoint.
+    const ipKey = getRateLimitKey(request, 'login');
+    const ipRetryAfter = checkRateLimit(ipKey, 5, 15 * 60 * 1000);
+    if (ipRetryAfter !== null) {
         return NextResponse.json(
-            { error: `Trop de tentatives. Reessayez dans ${Math.ceil(retryAfter / 60)} minutes.` },
+            { error: `Trop de tentatives. Reessayez dans ${Math.ceil(ipRetryAfter / 60)} minutes.` },
             { status: 429 },
         );
     }
@@ -18,6 +19,19 @@ export async function POST(request: NextRequest) {
 
     if (!username || !password) {
         return NextResponse.json({ error: 'Pseudo et mot de passe requis' }, { status: 400 });
+    }
+
+    // Per-username bucket — defends against credential stuffing with rotated
+    // IPs targeting a single account. Slightly more permissive window than
+    // IP bucket since a legitimate user retyping their password should not
+    // be locked out as easily.
+    const usernameKey = `login:user:${username.toLowerCase()}`;
+    const userRetryAfter = checkRateLimit(usernameKey, 10, 60 * 60 * 1000);
+    if (userRetryAfter !== null) {
+        return NextResponse.json(
+            { error: `Trop de tentatives sur ce compte. Reessayez dans ${Math.ceil(userRetryAfter / 60)} minutes.` },
+            { status: 429 },
+        );
     }
 
     const user = await loginUser(username, password);

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,10 +1,11 @@
 import { cookies } from 'next/headers';
-import { after } from 'next/server';
+import { NextResponse, after } from 'next/server';
 import { streamText, convertToModelMessages, stepCountIs } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 import { getUserFromSession, getUserFromApiKey } from '@/lib/session';
 import { buildSystemPrompt, buildGuestSystemPrompt } from '@/lib/chat';
 import { createChatTools, createGuestChatTools } from '@/lib/chat-tools';
+import { checkRateLimit, getRateLimitKey } from '@/lib/rate-limit';
 import { db } from '@/lib/db';
 import { langfuseSpanProcessor } from '@/instrumentation';
 
@@ -18,6 +19,25 @@ const openrouter = createOpenAI({
 export async function POST(req: Request) {
   const cookieStore = await cookies();
   const user = getUserFromApiKey(req) ?? getUserFromSession(cookieStore.get('session')?.value);
+
+  // Rate limit — guests are throttled harder than authed users (they burn
+  // OpenRouter credits on our key). API-key callers are not rate-limited
+  // (server-to-server use, already authenticated by their key).
+  const isApiKey = !!getUserFromApiKey(req);
+  if (!isApiKey) {
+    const key = user
+      ? `chat:user:${user.id}`
+      : getRateLimitKey(req, 'chat-guest');
+    const maxAttempts = user ? 40 : 8;
+    const windowMs = 60 * 60 * 1000; // 1 hour
+    const retryAfter = checkRateLimit(key, maxAttempts, windowMs);
+    if (retryAfter !== null) {
+      return NextResponse.json(
+        { error: `Trop de requêtes. Réessayez dans ${retryAfter}s.` },
+        { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+      );
+    }
+  }
 
   const body = await req.json();
   const { messages, events, sessionId } = body;

--- a/app/api/test/forced-video/route.ts
+++ b/app/api/test/forced-video/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createReadStream } from 'fs';
 import { stat } from 'fs/promises';
 import { Readable } from 'stream';
+import { cookies } from 'next/headers';
+import { getUserFromSession } from '@/lib/session';
 
 function parseRange(range: string, totalSize: number): { start: number; end: number } | null {
     const match = /^bytes=(\d*)-(\d*)$/.exec(range.trim());
@@ -22,6 +24,16 @@ function parseRange(range: string, totalSize: number): { start: number; end: num
 }
 
 export async function GET(request: NextRequest) {
+    // Auth gate — previously this route streamed an arbitrary video file to
+    // anyone hitting it. Require a valid session OR (admin) for prod safety.
+    // FORCED_RENTAL_FILE_PATH is a dev/staging convenience; we still let
+    // authenticated users use it (the original intent), but no longer anon.
+    const cookieStore = await cookies();
+    const user = getUserFromSession(cookieStore.get('session')?.value);
+    if (!user) {
+        return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
+    }
+
     const forcedPath = process.env.FORCED_RENTAL_FILE_PATH;
     if (!forcedPath) {
         return NextResponse.json(

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+// CSRF defense via Origin/Referer header check on every non-GET API route.
+//
+// Browsers send the Origin header on cross-origin POST/PUT/PATCH/DELETE and
+// also on same-origin POST in modern versions. Verifying that Origin matches
+// the request's own host blocks cross-site form submissions even though our
+// session cookies are `sameSite: 'lax'` (lax allows top-level GET cross-site
+// navigation, but does not by itself defend against tag-triggered POST).
+//
+// Exemptions:
+//   - GET / HEAD / OPTIONS are read-only, no CSRF risk.
+//   - Requests carrying a valid x-api-key header (server-to-server / scripted
+//     usage of /api/chat etc.). The key gate itself authenticates the caller.
+//
+// Replaces the (deleted) lib/csrf.ts double-submit token. Simpler, opt-out
+// by header rather than per-route opt-in.
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+export function middleware(req: NextRequest) {
+  // Only police /api/* routes — Next.js internals (RSC, _next/*) handle
+  // their own security model and our static pages are GET-only anyway.
+  if (!req.nextUrl.pathname.startsWith('/api/')) {
+    return NextResponse.next()
+  }
+  if (SAFE_METHODS.has(req.method)) {
+    return NextResponse.next()
+  }
+
+  // API-key authenticated callers are explicitly allowed cross-origin.
+  if (req.headers.get('x-api-key')) {
+    return NextResponse.next()
+  }
+
+  const origin = req.headers.get('origin')
+  const referer = req.headers.get('referer')
+  const host = req.headers.get('host')
+
+  // Build the expected same-origin (scheme + host) from the proxied request.
+  const forwardedProto = req.headers.get('x-forwarded-proto')
+  const proto = forwardedProto?.split(',')[0]?.trim() || req.nextUrl.protocol.replace(':', '')
+  const expectedOrigin = host ? `${proto}://${host}` : null
+
+  // Accept matching Origin OR matching Referer prefix (some legacy callers
+  // strip Origin but keep Referer).
+  if (origin && expectedOrigin && origin === expectedOrigin) {
+    return NextResponse.next()
+  }
+  if (!origin && referer && expectedOrigin && referer.startsWith(expectedOrigin)) {
+    return NextResponse.next()
+  }
+
+  return new NextResponse(
+    JSON.stringify({ error: 'Origine non autorisée' }),
+    { status: 403, headers: { 'content-type': 'application/json' } },
+  )
+}
+
+export const config = {
+  // Match every API route. The function above filters by method itself.
+  matcher: ['/api/:path*'],
+}


### PR DESCRIPTION
P1.1 — /api/test/forced-video unauthenticated
Anonymous GET on this route streamed FORCED_RENTAL_FILE_PATH bytes to anyone (Range support included). Now requires a valid session cookie; 401 otherwise. (`app/api/test/forced-video/route.ts:24-37`)

P1.2 — CSRF defense via Origin/Referer middleware
lib/csrf.ts was deleted in P3.11 without a replacement. Cookies are sameSite: 'lax', which does not by itself prevent cross-site form POSTs. New middleware.ts policies every /api/* non-GET request:
- Allows requests whose Origin matches the request's own host.
- Allows when Origin is absent if Referer matches expected origin.
- Allows requests carrying x-api-key (server-to-server, already authenticated by their key).
- Returns 403 otherwise. Verified: GET passes (200), POST without Origin → 403, POST with matching Origin → reaches handler, POST with evil Origin → 403.

P1.3 — /api/chat rate limit
Guest path was unthrottled, burning OpenRouter credits on every anonymous hit. Now: 40/hour per authed user, 8/hour per guest IP, x-api-key callers exempt. Verified: 9 guest hits → first 8 succeed, 9th returns 429 with Retry-After.
(`app/api/chat/route.ts:18-42`)

P1.4 — per-username login bucket
The IP-only bucket (5/15min) lets an attacker with rotated IPs credential-stuff a single account. Added a parallel username bucket (10/hour, lowercase key) that fires regardless of source IP. Verified with 12 hits from 12 different x-forwarded-for IPs: hits 1-10 reach the auth check (401 wrong-password), 11th returns 429 with a dedicated "Trop de tentatives sur ce compte" message.
(`app/api/auth/login/route.ts:7-30`)

All 4 verified end-to-end via curl smoke test. Build OK (`Middleware: 59.8 kB`).