### PR TITLE
perf(render): scaler de résolution dynamique adaptatif (fragment-bound)

### DIFF
--- a/src/components/interior/PostProcessingEffects.tsx
+++ b/src/components/interior/PostProcessingEffects.tsx
@@ -45,7 +45,13 @@ const SHARPEN_AMOUNT = 0.4
 // Raise is PROBED (after a saturation-free spell), not threshold-based: when vsync caps us we can't
 // see headroom, so we can't tell "holds 60 with margin" from "holds 60 exactly" — probe up slowly,
 // and if it re-saturates the reactive drop catches it.
-const DRS_MIN_SCALE = 0.5      // floor vs the Canvas max dpr — keeps a legible minimum in motion
+// Floor vs the Canvas max dpr — keeps a legible minimum in motion. Split desktop/mobile: the mobile
+// ceiling is already capped at 1.7, so a 0.5 floor would render at 0.85 dpr = HALF the linear resolution.
+// That is below the K7-legibility threshold we hit (and rejected) with TAAU 0.75× — see
+// memory/taau-mobile-rejected.md. 0.7 keeps the posters readable while still buying ~50 % of the pixels
+// back on a struggling phone. Desktop has real headroom above its floor, so it keeps 0.5.
+const DRS_MIN_SCALE_DESKTOP = 0.5
+const DRS_MIN_SCALE_MOBILE = 0.7
 const DRS_STEP = 0.1          // per-adjustment increment (discrete levels, fewer resizes)
 const DRS_DROP_MS = 22         // render-to-render EMA above → not holding 60 fps → drop (reactive)
 const DRS_PROBE_MS = 4000     // no saturation for this long → probe one step up (recover sharpness)
@@ -146,6 +152,7 @@ export function PostProcessingEffects({ isMobile = false }: PostProcessingEffect
 
   const renderAccumRef = useRef(0)
   // Adaptive resolution state
+  const drsMinScale = isMobile ? DRS_MIN_SCALE_MOBILE : DRS_MIN_SCALE_DESKTOP
   const dprMaxRef = useRef(0)         // Canvas max dpr (captured at first frame), the ceiling
   const dprScaleRef = useRef(1)       // current fraction of the ceiling (1 = full)
   const frameMsEmaRef = useRef(DRS_EMA_SEED) // EMA of the render-to-render interval (ms)
@@ -235,8 +242,8 @@ export function PostProcessingEffects({ isMobile = false }: PostProcessingEffect
       if (ema > DRS_DROP_MS) {
         // Not holding 60 fps → drop a step, reactively.
         lastSaturationRef.current = nowDrs
-        if (s > DRS_MIN_SCALE && nowDrs - lastDrsAdjustRef.current > DRS_DROP_COOLDOWN) {
-          applyScale(Math.max(DRS_MIN_SCALE, +(s - DRS_STEP).toFixed(2)))
+        if (s > drsMinScale && nowDrs - lastDrsAdjustRef.current > DRS_DROP_COOLDOWN) {
+          applyScale(Math.max(drsMinScale, +(s - DRS_STEP).toFixed(2)))
         }
       } else if (s < 1 && nowDrs - lastSaturationRef.current > DRS_PROBE_MS && nowDrs - lastDrsAdjustRef.current > DRS_RAISE_COOLDOWN) {
         // Saturation-free for a while → probe one step up to recover sharpness.

--- a/src/components/interior/PostProcessingEffects.tsx
+++ b/src/components/interior/PostProcessingEffects.tsx
@@ -153,6 +153,7 @@ export function PostProcessingEffects({ isMobile = false }: PostProcessingEffect
   const lastRenderTimeRef = useRef(0) // timestamp of the previous EFFECTIVE render (0 = none/reset)
   const lastSaturationRef = useRef(0) // last time the EMA exceeded DROP_MS
   const drsSettleUntilRef = useRef(0) // ignore intervals until this time (post-resize spike)
+  const drsEnabledRef = useRef(true)  // dev toggle (A/B the scaler) — always true in normal use
   const isTerminalOpen = useStore(state => state.isTerminalOpen)
   const isPlayerOpen = useStore(state => state.isPlayerOpen)
 
@@ -168,7 +169,8 @@ export function PostProcessingEffects({ isMobile = false }: PostProcessingEffect
     w.__drs = () => ({ scale: dprScaleRef.current, emaMs: +frameMsEmaRef.current.toFixed(1), maxPR: dprMaxRef.current, curPR: renderer.getPixelRatio() })
     // Force a high ceiling to test the scaler on a fast GPU (simulate Retina saturation).
     w.__drsSetMax = (pr: number) => { dprMaxRef.current = pr; dprScaleRef.current = 1; lastDrsAdjustRef.current = 0; frameMsEmaRef.current = DRS_EMA_SEED; lastRenderTimeRef.current = 0; setDpr(pr) }
-    return () => { delete w.__drs; delete w.__drsSetMax }
+    w.__drsEnable = (b: boolean) => { drsEnabledRef.current = !!b }
+    return () => { delete w.__drs; delete w.__drsSetMax; delete w.__drsEnable }
   }, [renderer, setDpr])
 
   useFrame((_, delta) => {
@@ -221,7 +223,9 @@ export function PostProcessingEffects({ isMobile = false }: PostProcessingEffect
       drsSettleUntilRef.current = nowDrs + DRS_SETTLE_MS // skip the RT-realloc spike
       lastRenderTimeRef.current = 0                       // don't measure across the resize
     }
-    if (!active) {
+    if (!drsEnabledRef.current) {
+      // Scaler disabled (dev A/B) — leave the resolution under manual control.
+    } else if (!active) {
       // At rest → full (supersampled) resolution for max sharpness when reading.
       if (dprScaleRef.current < 1 && nowDrs - lastDrsAdjustRef.current > DRS_DROP_COOLDOWN) applyScale(1)
       lastRenderTimeRef.current = 0 // idle gap must not pollute the active EMA

--- a/src/components/interior/PostProcessingEffects.tsx
+++ b/src/components/interior/PostProcessingEffects.tsx
@@ -30,8 +30,33 @@ const IDLE_INTERVAL = 1 / IDLE_FPS
 // posters without adding source resolution / VRAM. Tunable.
 const SHARPEN_AMOUNT = 0.4
 
+// --- Adaptive resolution scaler (dynamic resolution) --------------------------
+// The render is fragment-bound (cost ∝ pixels). On a Retina M1 Air the backbuffer
+// is ~8 MP (devicePixelRatio 2 × supersample 1.25) → unplayable. Instead of a fixed
+// low resolution, scale the pixelRatio with GPU load: drop it WHILE MOVING (you can't
+// perceive resolution in motion), restore the full supersampled res AT REST (when you
+// actually read the posters). The frame-interval EMA (rAF spacing under vsync) is the
+// load signal — no timestamp query needed. Scale is a fraction of the Canvas max dpr,
+// so the ceiling already encodes the desktop/mobile cap.
+// The signal is the interval between EFFECTIVE renders (after the 60-fps throttle gate), NOT the
+// rAF interval — the throttle caps rendering at 60 fps regardless of a 120 Hz display, so rAF
+// spacing (8.3 ms on 120 Hz) is meaningless; render-to-render is ≈16.7 ms when we hold 60 fps and
+// climbs when the GPU can't. Clean on a 60 Hz panel (the M1 Air — the actual target).
+// Raise is PROBED (after a saturation-free spell), not threshold-based: when vsync caps us we can't
+// see headroom, so we can't tell "holds 60 with margin" from "holds 60 exactly" — probe up slowly,
+// and if it re-saturates the reactive drop catches it.
+const DRS_MIN_SCALE = 0.5      // floor vs the Canvas max dpr — keeps a legible minimum in motion
+const DRS_STEP = 0.1          // per-adjustment increment (discrete levels, fewer resizes)
+const DRS_DROP_MS = 22         // render-to-render EMA above → not holding 60 fps → drop (reactive)
+const DRS_PROBE_MS = 4000     // no saturation for this long → probe one step up (recover sharpness)
+const DRS_DROP_COOLDOWN = 350 // min ms between drops
+const DRS_RAISE_COOLDOWN = 700
+const DRS_SETTLE_MS = 300     // after a resize, ignore intervals (RT realloc spike) this long
+const DRS_EMA_SEED = 16.7     // 60 fps
+
 export function PostProcessingEffects({ isMobile = false }: PostProcessingEffectsProps) {
   const { gl: renderer, scene, camera } = useThree()
+  const setDpr = useThree((s) => s.setDpr)
   const postProcessingRef = useRef<THREE.PostProcessing | null>(null)
   const bokehRef = useRef<ReturnType<typeof uniform> | null>(null)
   const bloomStrengthRef = useRef<ReturnType<typeof uniform> | null>(null)
@@ -120,6 +145,14 @@ export function PostProcessingEffects({ isMobile = false }: PostProcessingEffect
   }, [renderer, scene, camera, isMobile, dofTrigger])
 
   const renderAccumRef = useRef(0)
+  // Adaptive resolution state
+  const dprMaxRef = useRef(0)         // Canvas max dpr (captured at first frame), the ceiling
+  const dprScaleRef = useRef(1)       // current fraction of the ceiling (1 = full)
+  const frameMsEmaRef = useRef(DRS_EMA_SEED) // EMA of the render-to-render interval (ms)
+  const lastDrsAdjustRef = useRef(0)
+  const lastRenderTimeRef = useRef(0) // timestamp of the previous EFFECTIVE render (0 = none/reset)
+  const lastSaturationRef = useRef(0) // last time the EMA exceeded DROP_MS
+  const drsSettleUntilRef = useRef(0) // ignore intervals until this time (post-resize spike)
   const isTerminalOpen = useStore(state => state.isTerminalOpen)
   const isPlayerOpen = useStore(state => state.isPlayerOpen)
 
@@ -127,6 +160,16 @@ export function PostProcessingEffects({ isMobile = false }: PostProcessingEffect
   useEffect(() => {
     installRenderActivityListeners()
   }, [])
+
+  // Dev hooks to observe / drive the adaptive resolution scaler (Playwright + console).
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return
+    const w = window as unknown as Record<string, unknown>
+    w.__drs = () => ({ scale: dprScaleRef.current, emaMs: +frameMsEmaRef.current.toFixed(1), maxPR: dprMaxRef.current, curPR: renderer.getPixelRatio() })
+    // Force a high ceiling to test the scaler on a fast GPU (simulate Retina saturation).
+    w.__drsSetMax = (pr: number) => { dprMaxRef.current = pr; dprScaleRef.current = 1; lastDrsAdjustRef.current = 0; frameMsEmaRef.current = DRS_EMA_SEED; lastRenderTimeRef.current = 0; setDpr(pr) }
+    return () => { delete w.__drs; delete w.__drsSetMax }
+  }, [renderer, setDpr])
 
   useFrame((_, delta) => {
     if (document.hidden) return
@@ -167,12 +210,54 @@ export function PostProcessingEffects({ isMobile = false }: PostProcessingEffect
       )
     const interval = active ? ACTIVE_INTERVAL : IDLE_INTERVAL
 
+    // --- Adaptive resolution scaler: DECISION (runs every frame) -----------
+    // Reads the render-to-render EMA (fed at render time below) and adjusts the scale.
+    if (dprMaxRef.current === 0) dprMaxRef.current = renderer.getPixelRatio()
+    const nowDrs = performance.now()
+    const applyScale = (s: number) => {
+      dprScaleRef.current = s
+      setDpr(dprMaxRef.current * s)
+      lastDrsAdjustRef.current = nowDrs
+      drsSettleUntilRef.current = nowDrs + DRS_SETTLE_MS // skip the RT-realloc spike
+      lastRenderTimeRef.current = 0                       // don't measure across the resize
+    }
+    if (!active) {
+      // At rest → full (supersampled) resolution for max sharpness when reading.
+      if (dprScaleRef.current < 1 && nowDrs - lastDrsAdjustRef.current > DRS_DROP_COOLDOWN) applyScale(1)
+      lastRenderTimeRef.current = 0 // idle gap must not pollute the active EMA
+    } else {
+      const ema = frameMsEmaRef.current
+      const s = dprScaleRef.current
+      if (ema > DRS_DROP_MS) {
+        // Not holding 60 fps → drop a step, reactively.
+        lastSaturationRef.current = nowDrs
+        if (s > DRS_MIN_SCALE && nowDrs - lastDrsAdjustRef.current > DRS_DROP_COOLDOWN) {
+          applyScale(Math.max(DRS_MIN_SCALE, +(s - DRS_STEP).toFixed(2)))
+        }
+      } else if (s < 1 && nowDrs - lastSaturationRef.current > DRS_PROBE_MS && nowDrs - lastDrsAdjustRef.current > DRS_RAISE_COOLDOWN) {
+        // Saturation-free for a while → probe one step up to recover sharpness.
+        applyScale(Math.min(1, +(s + DRS_STEP).toFixed(2)))
+      }
+    }
+
     renderAccumRef.current += delta
     if (renderAccumRef.current < interval) return
     // Carry the remainder for an accurate cadence (resetting to 0 drops the
     // overshoot and under-shoots the target rate); clamp so a long stall
     // — tab switch, GC pause — can't unleash a burst of catch-up renders.
     renderAccumRef.current = Math.min(renderAccumRef.current - interval, interval)
+
+    // --- Adaptive resolution scaler: MEASURE (at effective render) ---------
+    // Interval between actual renders = true per-frame cost (≈16.7 ms when holding
+    // 60 fps, higher when the GPU can't). Skip right after a resize (RT realloc spike).
+    if (active) {
+      const tRender = performance.now()
+      if (lastRenderTimeRef.current > 0 && tRender >= drsSettleUntilRef.current) {
+        const ivl = Math.min(tRender - lastRenderTimeRef.current, 100) // clamp tab/GC stalls
+        frameMsEmaRef.current = frameMsEmaRef.current * 0.9 + ivl * 0.1
+      }
+      lastRenderTimeRef.current = tRender
+    }
 
     pp.render()
   }, 1)


### PR DESCRIPTION
## Diagnostic

Mesuré au préalable (Playwright, sweep de résolution) : le rendu est **fragment-bound**, ~3,35 ms/MP sur une machine M-series rapide. Sur un MacBook Air M1 Retina le backbuffer fait ~8-9 MP (`devicePixelRatio` 2 × supersample 1,25) → injouable. Ce sont les 15 RectAreaLights + les ~21 passes de post **multipliées par la résolution** qui coûtent.

## Approche

Plutôt qu'une résolution basse fixe (qui sacrifie la lisibilité des jaquettes en permanence), on ajuste le `pixelRatio` selon la charge GPU réelle : **on baisse en mouvement** (la résolution ne se perçoit pas quand on se déplace), **on restaure la pleine résolution supersamplée au repos** — c'est-à-dire exactement quand on lit les jaquettes.

Mécanique, dans le `useFrame` de `PostProcessingEffects`, à côté du throttle existant :

- **Signal** = intervalle entre rendus **effectifs** (après le gate 60 fps), pas l'rAF : le throttle découple rAF et rendu sur un écran 120 Hz, l'rAF mentirait.
- **Baisse réactive** quand l'EMA dépasse 22 ms (on ne tient pas le 60 fps).
- **Remontée sondée** après 4 s sans saturation, et non sur seuil bas : sous vsync on ne voit pas la marge disponible, donc on sonde d'un cran et la baisse réactive rattrape si besoin. Évite le « breathing » de résolution d'un contrôleur naïf.
- Fenêtre d'ignorance de 300 ms après un resize (réallocation des render targets).
- Au repos → retour immédiat à la pleine résolution.

## Plancher distinct desktop / mobile

- **Desktop 0,5** — il a une vraie marge au-dessus (supersample 1,25 × dpr natif).
- **Mobile 0,7** — le plafond mobile est déjà capé à 1,7 par le Canvas ; un plancher à 0,5 donnerait 0,85 de dpr effectif, soit la **moitié** de la résolution linéaire. C'est plus agressif que le TAAU 0,75× déjà testé et **rejeté** parce qu'il rendait les jaquettes K7 illisibles (règle actée : ne pas redescendre sous 0,85× tant que les K7 sont le contenu principal). 0,7 récupère encore ~50 % des pixels sur un téléphone qui sature.

## Non-régression

Sur une machine qui tient déjà le 60 fps, **rien ne change** : l'EMA reste à ~16,7 ms, sous le seuil de 22 ms, le scale reste à 1. Le `dpr` modifié ne peut pas fuiter vers une autre scène — il n'y a qu'un seul `<Canvas>` (`InteriorScene.tsx`) et `PostProcessingEffects` vit dedans. Les hooks dev (`__drs`, `__drsSetMax`, `__drsEnable`) sont derrière `process.env.NODE_ENV === 'production'`, donc absents du bundle de prod.

## Vérifications

- `npx tsc --noEmit` → 0 erreur
- `npm run test:phase` → 110 tests, 102 pass / 8 fail, **identique à la baseline `main`**
- `rm -rf .next && npm run build` → exit 0
- Validé en local via Playwright avec plafond forcé à 2,8 (simulation Retina) : mouvement 9,1 MP injouable → 2,3 MP fluide ; repos → 9,1 MP restaurés

## ⚠️ Limites connues

- **Jamais exécuté sur la vraie cible M1** (machine de dev = MacBook Pro M4 Pro, ~3,5× plus rapide). Le gain est raisonné et mesuré par simulation, pas constaté sur l'appareil visé.
- **Jamais testé sur un téléphone réel** — d'où le plancher mobile prudent à 0,7.
- Chaque changement de palier déclenche un resize R3F → réallocation des cibles de rendu du post. C'est borné (cooldown 350 ms, 5 paliers max) mais peut produire un micro-accroc, ironiquement sur le GPU faible qui l'a déclenché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkH623mYnPPkg9hz9exkjY